### PR TITLE
Support MySQL 8.0.32 and later

### DIFF
--- a/include/audit_handler.h
+++ b/include/audit_handler.h
@@ -32,6 +32,10 @@
 #define my_rwlock_init(lock, unused)	native_rw_init(lock)
 #endif
 
+#if (!defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80031)
+using TABLE_LIST = Table_ref;
+#endif
+
 class THD;
 
 #define MAX_NUM_QUERY_TABLE_ELEM 100

--- a/offset-extract/offset-extract.sh
+++ b/offset-extract/offset-extract.sh
@@ -135,7 +135,14 @@ VIEW_TABLES=""
 if echo $MYVER | grep -P '^(8\.0)' > /dev/null
 then
 	LEX_COMMENT='printf ", 0"'
-	VIEW_TABLES="print_offset TABLE_LIST view_tables"
+	if echo $MYVER | grep -P '^8\.0\.(3[2-9]|[4-9]\d)' > /dev/null
+	then
+		# MySQL 8.0.32 and laters
+		VIEW_TABLES="print_offset Table_ref view_tables"
+	else
+		# MySQL 8.0.32 and ealiers
+		VIEW_TABLES="print_offset TABLE_LIST view_tables"
+	fi
 else
 	LEX_COMMENT="print_offset LEX comment"
 	VIEW_TABLES='printf ", 0"'

--- a/src/audit_handler.cc
+++ b/src/audit_handler.cc
@@ -833,6 +833,25 @@ static bool parse_length_encoded_string(
     , data_length
     , nchars_max
   );
+#elif MYSQL_VERSION_ID >= 80031
+  /*
+    TODO: Migrate the data itself to UTF8MB4,
+    this is still UTF8MB3 printed in a UTF8MB4 column.
+  */
+  const char *well_formed_error_pos = NULL, *cannot_convert_error_pos = NULL,
+             *from_end_pos = NULL;
+  copy_length = well_formed_copy_nchars(
+      &my_charset_utf8mb3_bin
+    , dest
+    , dest_size
+    , from_cs
+    , *ptr
+    , data_length
+    , nchars_max
+    , &well_formed_error_pos
+    , &cannot_convert_error_pos
+    , &from_end_pos
+  );
 #else
   /*
     TODO: Migrate the data itself to UTF8MB4,
@@ -1086,7 +1105,7 @@ ssize_t Audit_json_formatter::event_format(ThdSesData *pThdData, IWriter *writer
 			uint errors = 0;
 
 			size_t len = copy_and_convert(to, to_amount,
-#if defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 100504
+#if (defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 100504) || (!defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80031)
 					&my_charset_utf8mb3_general_ci,
 #else
 					&my_charset_utf8_general_ci,


### PR DESCRIPTION
- TABLE_LIST -> Table_ref
- my_charset_utf8_general_ci -> my_charset_utf8mb3_general_ci

This PR includes https://github.com/trellix-enterprise/mysql-audit/pull/273